### PR TITLE
Configure babel to use native es6 modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-1"],
+  "presets": [[ "es2015", { "modules": false } ], "stage-1"],
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
       "ignoreComments": false
     }],
     "comma-dangle": "off",
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true }]
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true }],
+    "import/prefer-default-export": "off"
   }
 }


### PR DESCRIPTION
- Enabled treeshaking in Webpack 2